### PR TITLE
🐛 fix: fix routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,0 @@
-import React from "react";
-import { RouterProvider } from "react-router-dom";
-import router from "./routes";
-
-export default function App() {
-  return <RouterProvider router={router} />;
-}

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,11 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx";
 import "./index.css";
+import Router from "./routes.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <Router />
   </React.StrictMode>
 );

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -69,19 +69,17 @@ import LoginPage from "./pages/login/index";
 import Pagenotfound from "./pages/Pagenotfound/index";
 import { AuthProvider } from "./contexts/auth";
 
-function router() {
+function Router() {
   return (
-    <AuthProvider>
-      <RouterProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" index element={<MainPage />} />
-            <Route path="/login" element={<LoginPage />} />
-          </Routes>
-        </BrowserRouter>
-      </RouterProvider>
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route path="/" index element={<MainPage />} />
+          <Route path="/login" element={<LoginPage />} />
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
 
-export default router;
+export default Router;


### PR DESCRIPTION
O problema principal era o uso incorreto do RouterProvider e do BrowserRouter juntos. O RouterProvider é usado para fornecer o contexto do roteador ao resto do aplicativo e geralmente não é necessário quando já tá usando o BrowserRouter. 
Segunda coisa: o AuthProvider tava sendo renderizado fora do contexto do BrowserRouter.